### PR TITLE
Fix BaseConverter misspell

### DIFF
--- a/ArcticCloud.egg-info/PKG-INFO
+++ b/ArcticCloud.egg-info/PKG-INFO
@@ -14,7 +14,7 @@ Description: It is a **Package** Created to solve few problems faced by people e
         
         ```
         This Module will Convert a number from the given base to any other base.
-        Usage : from ArcticCloud import BaseConvertor as b
+        Usage : from ArcticCloud import BaseConverter as b
         # Say, you will convert from Binary to Hexadecimal,
         v1 = b.Binary_to_Hexadecimal("11011101.111010") # bound the method calling to a variable and print it to get the desired result, 
         

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Class **BaseConverter**:
 
 ```
 This Module will Convert a number from the given base to any other base.
-Usage : from ArcticCloud import BaseConvertor as b
+Usage : from ArcticCloud import BaseConverter as b
 # Say, you will convert from Binary to Hexadecimal,
 v1 = b.Binary_to_Hexadecimal("11011101.111010") # bound the method calling to a variable and print it to get the desired result, 
 


### PR DESCRIPTION
## Description 
Fix the `BaseConverter` misspell as `BaseConvertor` in the documentation.

Fixes #1 